### PR TITLE
improve compatibility for older browsers

### DIFF
--- a/metalsmith.js
+++ b/metalsmith.js
@@ -212,7 +212,8 @@ const ms = metalsmith(import.meta.dirname)
         'scripts/index': 'contents/scripts/index.js',
         'scripts/search': 'contents/scripts/search.js',
         'style/screen': 'contents/style/screen.css'
-      }
+      },
+      target: 'safari16'
     })
   )
   .use(markdown())


### PR DESCRIPTION
set esbuild target to `safari16` which tells esbuild to transform/flatten CSS nesting
